### PR TITLE
Refactor phpQuery callbacks for modern PHP

### DIFF
--- a/modules/utils/vendor/phpQuery/phpQuery/Callback.php
+++ b/modules/utils/vendor/phpQuery/phpQuery/Callback.php
@@ -23,7 +23,7 @@ interface ICallbackNamed {
  * @link http://code.google.com/p/phpquery/wiki/Callbacks#Param_Structures
  * @author Tobiasz Cudnik <tobiasz.cudnik/gmail.com>
  * 
- * @TODO??? return fake forwarding function created via create_function
+ * @TODO??? return fake forwarding function created via a closure
  * @TODO honor paramStructure
  */
 class Callback
@@ -59,17 +59,17 @@ class Callback
 //	}
 }
 /**
- * Shorthand for new Callback(create_function(...), ...);
+ * Shorthand for new Callback(anonymous function, ...);
  * 
  * @author Tobiasz Cudnik <tobiasz.cudnik/gmail.com>
  */
 class CallbackBody extends Callback {
 	public function __construct($paramList, $code, $param1 = null, $param2 = null, 
 			$param3 = null) {
-		$params = func_get_args();
-		$params = array_slice($params, 2);
-		$this->callback = create_function($paramList, $code);
-		$this->params = $params;
+                $params = func_get_args();
+                $params = array_slice($params, 2);
+                $this->callback = eval('return function(' . $paramList . ') {' . $code . '};');
+                $this->params = $params;
 	}
 }
 /**

--- a/modules/utils/vendor/phpQuery/phpQuery/Zend/Json/Decoder.php
+++ b/modules/utils/vendor/phpQuery/phpQuery/Zend/Json/Decoder.php
@@ -320,7 +320,7 @@ class Zend_Json_Decoder
         $i          = $this->_offset;
         $start      = $i;
 
-        switch ($str{$i}) {
+        switch ($str[$i]) {
             case '{':
                $this->_token = self::LBRACE;
                break;
@@ -347,13 +347,13 @@ class Zend_Json_Decoder
                         break;
                     }
 
-                    $chr = $str{$i};
+                    $chr = $str[$i];
                     if ($chr == '\\') {
                         $i++;
                         if ($i >= $str_length) {
                             break;
                         }
-                        $chr = $str{$i};
+                        $chr = $str[$i];
                         switch ($chr) {
                             case '"' :
                                 $result .= '"';
@@ -425,7 +425,7 @@ class Zend_Json_Decoder
             return($this->_token);
         }
 
-        $chr = $str{$i};
+        $chr = $str[$i];
         if ($chr == '-' || $chr == '.' || ($chr >= '0' && $chr <= '9')) {
             if (preg_match('/-?([0-9])*(\.[0-9]*)?((e|E)((-|\+)?)[0-9]+)?/s',
                 $str, $matches, PREG_OFFSET_CAPTURE, $start) && $matches[0][1] == $start) {

--- a/modules/utils/vendor/phpQuery/phpQuery/phpQueryObject.php
+++ b/modules/utils/vendor/phpQuery/phpQuery/phpQueryObject.php
@@ -965,20 +965,22 @@ class phpQueryObject
 					"input[type=$class]", new CallbackParam()
 				)->elements;
 			break;
-			case 'parent':
-				$this->elements = $this->map(
-					create_function('$node', '
-						return $node instanceof DOMELEMENT && $node->childNodes->length
-							? $node : null;')
-				)->elements;
-			break;
-			case 'empty':
-				$this->elements = $this->map(
-					create_function('$node', '
-						return $node instanceof DOMELEMENT && $node->childNodes->length
-							? null : $node;')
-				)->elements;
-			break;
+                        case 'parent':
+                                $this->elements = $this->map(
+                                        function ($node) {
+                                                return $node instanceof DOMELEMENT && $node->childNodes->length
+                                                        ? $node : null;
+                                        }
+                                )->elements;
+                        break;
+                        case 'empty':
+                                $this->elements = $this->map(
+                                        function ($node) {
+                                                return $node instanceof DOMELEMENT && $node->childNodes->length
+                                                        ? null : $node;
+                                        }
+                                )->elements;
+                        break;
 			case 'disabled':
 			case 'selected':
 			case 'checked':
@@ -987,124 +989,135 @@ class phpQueryObject
 					"[$class]", new CallbackParam()
 				)->elements;
 			break;
-			case 'enabled':
-				$this->elements = $this->map(
-					create_function('$node', '
-						return pq($node)->not(":disabled") ? $node : null;')
-				)->elements;
+                        case 'enabled':
+                                $this->elements = $this->map(
+                                        function ($node) {
+                                                return pq($node)->not(":disabled") ? $node : null;
+                                        }
+                                )->elements;
+                        break;
+                        case 'header':
+                                $this->elements = $this->map(
+                                        function ($node) {
+                                                $isHeader = isset($node->tagName) && in_array($node->tagName, array(
+                                                        "h1", "h2", "h3", "h4", "h5", "h6", "h7"
+                                                ));
+                                                return $isHeader
+                                                        ? $node
+                                                        : null;
+                                        }
+                                )->elements;
+//                              $this->elements = $this->map(
+//                                      function ($node) {
+//                                              $node = pq($node);
+//                                              return $node->is("h1")
+//                                                      || $node->is("h2")
+//                                                      || $node->is("h3")
+//                                                      || $node->is("h4")
+//                                                      || $node->is("h5")
+//                                                      || $node->is("h6")
+//                                                      || $node->is("h7")
+//                                                      ? $node
+//                                                      : null;
+//                                      }
+//                              )->elements;
 			break;
-			case 'header':
-				$this->elements = $this->map(
-					create_function('$node',
-						'$isHeader = isset($node->tagName) && in_array($node->tagName, array(
-							"h1", "h2", "h3", "h4", "h5", "h6", "h7"
-						));
-						return $isHeader
-							? $node
-							: null;')
-				)->elements;
-//				$this->elements = $this->map(
-//					create_function('$node', '$node = pq($node);
-//						return $node->is("h1")
-//							|| $node->is("h2")
-//							|| $node->is("h3")
-//							|| $node->is("h4")
-//							|| $node->is("h5")
-//							|| $node->is("h6")
-//							|| $node->is("h7")
-//							? $node
-//							: null;')
-//				)->elements;
-			break;
-			case 'only-child':
-				$this->elements = $this->map(
-					create_function('$node',
-						'return pq($node)->siblings()->size() == 0 ? $node : null;')
-				)->elements;
-			break;
-			case 'first-child':
-				$this->elements = $this->map(
-					create_function('$node', 'return pq($node)->prevAll()->size() == 0 ? $node : null;')
-				)->elements;
-			break;
-			case 'last-child':
-				$this->elements = $this->map(
-					create_function('$node', 'return pq($node)->nextAll()->size() == 0 ? $node : null;')
-				)->elements;
-			break;
+                        case 'only-child':
+                                $this->elements = $this->map(
+                                        function ($node) {
+                                                return pq($node)->siblings()->size() == 0 ? $node : null;
+                                        }
+                                )->elements;
+                        break;
+                        case 'first-child':
+                                $this->elements = $this->map(
+                                        function ($node) {
+                                                return pq($node)->prevAll()->size() == 0 ? $node : null;
+                                        }
+                                )->elements;
+                        break;
+                        case 'last-child':
+                                $this->elements = $this->map(
+                                        function ($node) {
+                                                return pq($node)->nextAll()->size() == 0 ? $node : null;
+                                        }
+                                )->elements;
+                        break;
 			case 'nth-child':
 				$param = trim($args, "\"'");
 				if (! $param)
 					break;
 					// nth-child(n+b) to nth-child(1n+b)
-				if ($param{0} == 'n')
-					$param = '1'.$param;
+                                if ($param[0] == 'n')
+                                        $param = '1'.$param;
 				// :nth-child(index/even/odd/equation)
-				if ($param == 'even' || $param == 'odd')
-					$mapped = $this->map(
-						create_function('$node, $param',
-							'$index = pq($node)->prevAll()->size()+1;
-							if ($param == "even" && ($index%2) == 0)
-								return $node;
-							else if ($param == "odd" && $index%2 == 1)
-								return $node;
-							else
-								return null;'),
-						new CallbackParam(), $param
-					);
-				else if (mb_strlen($param) > 1 && $param{1} == 'n')
+                                if ($param == 'even' || $param == 'odd')
+                                        $mapped = $this->map(
+                                                function ($node, $param) {
+                                                        $index = pq($node)->prevAll()->size()+1;
+                                                        if ($param == "even" && ($index%2) == 0)
+                                                                return $node;
+                                                        else if ($param == "odd" && $index%2 == 1)
+                                                                return $node;
+                                                        else
+                                                                return null;
+                                                },
+                                                new CallbackParam(), $param
+                                        );
+                                else if (mb_strlen($param) > 1 && $param[1] == 'n')
 					// an+b
-					$mapped = $this->map(
-						create_function('$node, $param',
-							'$prevs = pq($node)->prevAll()->size();
-							$index = 1+$prevs;
-							$b = mb_strlen($param) > 3
-								? $param{3}
-								: 0;
-							$a = $param{0};
-							if ($b && $param{2} == "-")
-								$b = -$b;
-							if ($a > 0) {
-								return ($index-$b)%$a == 0
-									? $node
-									: null;
-								phpQuery::debug($a."*".floor($index/$a)."+$b-1 == ".($a*floor($index/$a)+$b-1)." ?= $prevs");
-								return $a*floor($index/$a)+$b-1 == $prevs
-										? $node
-										: null;
-							} else if ($a == 0)
-								return $index == $b
-										? $node
-										: null;
-							else
-								// negative value
-								return $index <= $b
-										? $node
-										: null;
-//							if (! $b)
-//								return $index%$a == 0
-//									? $node
-//									: null;
-//							else
-//								return ($index-$b)%$a == 0
-//									? $node
-//									: null;
-							'),
-						new CallbackParam(), $param
-					);
+                                        $mapped = $this->map(
+                                                function ($node, $param) {
+                                                        $prevs = pq($node)->prevAll()->size();
+                                                        $index = 1 + $prevs;
+                                                        $b = mb_strlen($param) > 3
+                                                                ? $param[3]
+                                                                : 0;
+                                                        $a = $param[0];
+                                                        if ($b && $param[2] == "-")
+                                                                $b = -$b;
+                                                        if ($a > 0) {
+                                                                return ($index - $b) % $a == 0
+                                                                        ? $node
+                                                                        : null;
+                                                                phpQuery::debug($a."*".floor($index/$a)."+$b-1 == ".($a*floor($index/$a)+$b-1)." ?= $prevs");
+                                                                return $a*floor($index/$a)+$b-1 == $prevs
+                                                                                ? $node
+                                                                                : null;
+                                                        } else if ($a == 0)
+                                                                return $index == $b
+                                                                                ? $node
+                                                                                : null;
+                                                        else
+                                                                // negative value
+                                                                return $index <= $b
+                                                                                ? $node
+                                                                                : null;
+        //                                                      if (! $b)
+        //                                                              return $index%$a == 0
+        //                                                                      ? $node
+        //                                                                      : null;
+        //                                                      else
+        //                                                              return ($index-$b)%$a == 0
+        //                                                                      ? $node
+        //                                                                      : null;
+                                                },
+                                                new CallbackParam(), $param
+                                        );
 				else
 					// index
-					$mapped = $this->map(
-						create_function('$node, $index',
-							'$prevs = pq($node)->prevAll()->size();
-							if ($prevs && $prevs == $index-1)
-								return $node;
-							else if (! $prevs && $index == 1)
-								return $node;
-							else
-								return null;'),
-						new CallbackParam(), $param
-					);
+                                        $mapped = $this->map(
+                                                function ($node, $index) {
+                                                        $prevs = pq($node)->prevAll()->size();
+                                                        if ($prevs && $prevs == $index-1)
+                                                                return $node;
+                                                        else if (! $prevs && $index == 1)
+                                                                return $node;
+                                                        else
+                                                                return null;
+                                                },
+                                                new CallbackParam(), $param
+                                        );
 				$this->elements = $mapped->elements;
 			break;
 			default:

--- a/modules/utils/vendor/phpQuery/phpQuery/plugins/Scripts/google_login.php
+++ b/modules/utils/vendor/phpQuery/phpQuery/plugins/Scripts/google_login.php
@@ -34,14 +34,14 @@ $self->document->xhr = phpQuery::$plugins->browserGet(
 	'https://www.google.com/accounts/Login',
 	$ndfasui8923
 );
-//$self->document->xhr = phpQuery::$plugins->browserGet('https://www.google.com/accounts/Login', create_function('$browser', "
-//	\$browser
-//		->WebBrowser()
-//		->find('#Email')
-//			->val('{$config['google_login'][0]}')->end()
-//		->find('#Passwd')
-//			->val('".str_replace("'", "\\'", $config['google_login'][1])."')
-//			->parents('form')
-//				->submit();"
-//));
+//$self->document->xhr = phpQuery::$plugins->browserGet('https://www.google.com/accounts/Login', function ($browser) use ($config) {
+//      $browser
+//              ->WebBrowser()
+//              ->find('#Email')
+//                      ->val($config['google_login'][0])->end()
+//              ->find('#Passwd')
+//                      ->val(str_replace("'", "\\'", $config['google_login'][1]))
+//                      ->parents('form')
+//                              ->submit();
+//});
 ?>

--- a/modules/utils/vendor/phpQuery/phpQuery/plugins/WebBrowser.php
+++ b/modules/utils/vendor/phpQuery/phpQuery/plugins/WebBrowser.php
@@ -354,7 +354,7 @@ function resolve_url($base, $url) {
         // Step 3
         if (preg_match('!^[a-z]+:!i', $url)) return $url;
         $base = parse_url($base);
-        if ($url{0} == "#") {
+        if ($url[0] == "#") {
                 // Step 2 (fragment)
                 $base['fragment'] = substr($url, 1);
                 return unparse_url($base);
@@ -367,7 +367,7 @@ function resolve_url($base, $url) {
                         'scheme'=>$base['scheme'],
                         'path'=>substr($url,2),
                 ));
-        } else if ($url{0} == "/") {
+        } else if ($url[0] == "/") {
                 // Step 5
                 $base['path'] = $url;
         } else {


### PR DESCRIPTION
## Summary
- Replace deprecated `create_function` calls with closures
- Update string offset access to bracket syntax
- Refresh sample plugin code to use closure style

## Testing
- `php -l modules/utils/vendor/phpQuery/phpQuery/Callback.php`
- `php -l modules/utils/vendor/phpQuery/phpQuery/phpQueryObject.php`
- `php -l modules/utils/vendor/phpQuery/phpQuery/plugins/Scripts/google_login.php`
- `php -l modules/utils/vendor/phpQuery/phpQuery/plugins/WebBrowser.php`
- `php -l modules/utils/vendor/phpQuery/phpQuery/Zend/Json/Decoder.php`
- `php -r 'require "modules/utils/vendor/phpQuery/phpQuery.php"; $doc = phpQuery::newDocument("<div><p class=\"first\">a</p><p>b</p><p>c</p></div>"); echo $doc["p:first-child"]->text()."-".$doc["p:nth-child(2)"]->text();'`

------
https://chatgpt.com/codex/tasks/task_e_68966892ac84832ca45d7e5e6ea34c0a